### PR TITLE
add manager to department

### DIFF
--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -36,6 +36,11 @@ const LoginPage: React.FC<Props> = (props) => {
         description: 'Member of Engineering Department',
         isAdmin: false,
       },
+      {
+        userId: 'cf02fc55-5942-49ee-8193-70b002e92ef8',
+        description: 'Manager of Engineering Department',
+        isAdmin: false,
+      },
     ];
 
     return users.map((u) => (

--- a/server/src/auth/policies/core/members.polar
+++ b/server/src/auth/policies/core/members.polar
@@ -7,7 +7,7 @@ allow_field(user: User, "read", member: Member, field) if
   field in Member.PUBLIC_FIELDS or
   # private fields are readable only by hr or self
   (field in Member.PRIVATE_FIELDS and 
-    (has_role(user, "hr_member", member) or has_role(user, "self", member))
+    (has_role(user, "hr_member", member) or has_role(user, "self", member) or has_role(user, "manager", user.memberInfo.department))
   ); # fragile to use department name
 
 allow_field(user: User, "update", member: Member, field) if
@@ -15,3 +15,12 @@ allow_field(user: User, "update", member: Member, field) if
   (field in Member.PUBLIC_FIELDS and (has_role(user, "hr_member", member) or has_role(user, "self", member))) or
   # private fields like salaries are updatable only by hr
   (field in Member.PRIVATE_FIELDS and has_role(user, "hr_member", member));
+
+has_role(user: User, "manager", department: Department) if user.memberInfo.id = department.managerMemberId;
+
+has_relation(department: Department, "department", member: Member) if
+  member.department.id = department.id;
+
+has_permission(user: User, "read", _member: Member) if
+  has_role(user, "manager", user.memberInfo.department) and
+  has_relation(user.memberInfo.department, "department", user.memberInfo);

--- a/server/src/auth/policies/members.polar
+++ b/server/src/auth/policies/members.polar
@@ -1,5 +1,6 @@
 resource Department {
   permissions = ["read"];
+  roles = ["manager"];
 }
 
 has_permission(_: User, "read", _department: Department);
@@ -16,5 +17,3 @@ resource Member {
   "update" if "hr_member";
 }
 
-has_relation(department: Department, "department", member: Member) if
-  member.department = department;

--- a/server/src/auth/policies/orm/members.polar
+++ b/server/src/auth/policies/orm/members.polar
@@ -1,3 +1,12 @@
 has_role(user: User, "hr_member", _member: Member) if user.member.department.name = "hr";
 has_role(user: User, "self", member: Member) if user.member.id = member.id;
 has_role(user: User, "same_department", member: Member) if user.member.department.id = member.department.id;
+
+has_role(user: User, "manager", department: Department) if user.member.id = department.managerMemberId;
+
+has_relation(department: Department, "department", member: Member) if
+  member.department.id = department.id;
+
+has_permission(user: User, "read", _member: Member) if
+  has_role(user, "manager", user.member.department) and
+  has_relation(user.member.department, "department", user.member);

--- a/server/src/auth/shared/createOso.ts
+++ b/server/src/auth/shared/createOso.ts
@@ -78,6 +78,7 @@ export async function createSqliteDataFilterOso(connection: Connection) {
     fields: {
       id: String,
       name: String,
+      managerMemberId: String,
     },
   });
   osoDataFilter.registerClass(MemberOrm, {

--- a/server/src/database/constants.ts
+++ b/server/src/database/constants.ts
@@ -17,4 +17,8 @@ export const USERS = {
     userId: '574319c9-7d97-4616-8ae6-ee78377e0cb6',
     memberId: 'abc750b3-3cef-4833-b7f2-24a8910e430d',
   },
+  nonAdminAndEngineerManager: {
+    userId: 'cf02fc55-5942-49ee-8193-70b002e92ef8',
+    memberId: 'dc9b5330-3051-4cec-8c22-6fb95b0591dd',
+  },
 };

--- a/server/src/database/seeds/create-departments.seed.ts
+++ b/server/src/database/seeds/create-departments.seed.ts
@@ -1,7 +1,8 @@
 import { DepartmentOrm } from '../../members/shared/typeorm/departmentOrm';
 import { Connection } from 'typeorm';
 import { Factory, Seeder } from 'typeorm-seeding';
-import { DEPARTMENT_IDS } from '../constants';
+import { DEPARTMENT_IDS, USERS } from '../constants';
+import faker from 'faker';
 
 export default class CreateDepartments implements Seeder {
   async run(factory: Factory, connection: Connection): Promise<void> {
@@ -13,14 +14,17 @@ export default class CreateDepartments implements Seeder {
         {
           id: DEPARTMENT_IDS.engineering,
           name: 'engineering',
+          managerMemberId: USERS.nonAdminAndEngineerManager.memberId,
         },
         {
           id: DEPARTMENT_IDS.itsec,
           name: 'itsec',
+          managerMemberId: faker.random.uuid(),
         },
         {
           id: DEPARTMENT_IDS.hr,
           name: 'hr',
+          managerMemberId: faker.random.uuid(),
         },
       ])
       .execute();

--- a/server/src/database/seeds/create-users-members.seed.ts
+++ b/server/src/database/seeds/create-users-members.seed.ts
@@ -36,6 +36,16 @@ export default class CreateUsersAndMembers implements Seeder {
       memberId: engineeringMember.id,
     });
 
+    const engineeringManager = await factory(MemberOrm)().create({
+      id: USERS.nonAdminAndEngineerManager.memberId,
+      departmentId: DEPARTMENT_IDS.engineering,
+    });
+    await factory(UserOrm)().create({
+      id: USERS.nonAdminAndEngineerManager.userId,
+      isAdmin: false,
+      memberId: engineeringManager.id,
+    });
+
     const members = await factory(MemberOrm)().createMany(20);
     for (const member of members) {
       await factory(UserOrm)().create({ memberId: member.id });

--- a/server/src/members/shared/department.ts
+++ b/server/src/members/shared/department.ts
@@ -1,3 +1,7 @@
 export class Department {
-  constructor(public id: string, public name: string) {}
+  constructor(
+    public id: string,
+    public name: string,
+    public managerMemberId: string
+  ) {}
 }

--- a/server/src/members/shared/typeorm/departmentOrm.ts
+++ b/server/src/members/shared/typeorm/departmentOrm.ts
@@ -9,15 +9,23 @@ export class DepartmentOrm {
   @Column()
   name!: string;
 
+  // Usually this wouldn't be simple string id.
+  // It should be a many to many relation with member roles
+  // for a department but for simplicity, we'll just hold a 
+  // manager member id.
+  @Column()
+  managerMemberId!: string;
+
   static fromDepartment(department: Department) {
     const d = new DepartmentOrm();
     d.id = department.id;
     d.name = department.name;
+    d.managerMemberId = department.managerMemberId;
     return d;
   }
 
   toDepartment(): Department {
-    const d = new Department(this.id, this.name);
+    const d = new Department(this.id, this.name, this.managerMemberId);
     return d;
   }
 }

--- a/server/tests/integration/members/listAllMembers.test.ts
+++ b/server/tests/integration/members/listAllMembers.test.ts
@@ -50,45 +50,68 @@ describe('ListAllMembers', () => {
   });
   describe('Authorized request', () => {
     describe('non HR member', () => {
-      let res: request.Response;
-      let loggedInUser: typeof USERS[keyof typeof USERS];
-      beforeAll(async () => {
-        loggedInUser = USERS.nonAdminAndEngineer;
-        res = await authorizeRequest(
-          request(app).get('/members'),
-          loggedInUser.userId
-        ).expect(200);
-        expect(res.body.members).toBeInstanceOf(Array);
-        expect(res.body.members.length).toBeGreaterThan(1);
-      });
+      describe('non Manager of department', () => {
+        let res: request.Response;
+        let loggedInUser: typeof USERS[keyof typeof USERS];
+        beforeAll(async () => {
+          loggedInUser = USERS.nonAdminAndEngineer;
+          res = await authorizeRequest(
+            request(app).get('/members'),
+            loggedInUser.userId
+          ).expect(200);
+          expect(res.body.members).toBeInstanceOf(Array);
+          expect(res.body.members.length).toBeGreaterThan(1);
+        });
 
-      it('should return only members of the users department', async () => {
-        const { members } = res.body;
-        for (const member of members) {
-          expect(member.department.id).toBe(DEPARTMENT_IDS.engineering);
-        }
-      });
+        it('should return only members of the users department', async () => {
+          const { members } = res.body;
+          for (const member of members) {
+            expect(member.department.id).toBe(DEPARTMENT_IDS.engineering);
+          }
+        });
 
-      it("should omit member's private fields such as salaries except for the logged in user and should not be editable", () => {
-        const { members } = res.body;
-        const membersLoggedInUserExcluded = members.filter(
-          (m: any) => m.id !== loggedInUser.memberId
-        );
-        for (const member of membersLoggedInUserExcluded) {
-          expect(member.salary).toBeUndefined();
-          expect(member.age).toBeUndefined();
-          expect(member.editable).toBeFalsy();
-        }
-      });
+        it("should omit member's private fields such as salaries except for the logged in user and should not be editable", () => {
+          const { members } = res.body;
+          const membersLoggedInUserExcluded = members.filter(
+            (m: any) => m.id !== loggedInUser.memberId
+          );
+          for (const member of membersLoggedInUserExcluded) {
+            expect(member.salary).toBeUndefined();
+            expect(member.age).toBeUndefined();
+            expect(member.editable).toBeFalsy();
+          }
+        });
 
-      it("should not omit logged in user's private fields such as salaries and should be editable", async () => {
-        const { members } = res.body;
-        const loggedInUserMember = members.find(
-          (m: any) => m.id === loggedInUser.memberId
-        );
-        expect(loggedInUserMember.salary).toBeDefined();
-        expect(loggedInUserMember.age).toBeDefined();
-        expect(loggedInUserMember.editable).toBe(true);
+        it("should not omit logged in user's private fields such as salaries and should be editable", async () => {
+          const { members } = res.body;
+          const loggedInUserMember = members.find(
+            (m: any) => m.id === loggedInUser.memberId
+          );
+          expect(loggedInUserMember.salary).toBeDefined();
+          expect(loggedInUserMember.age).toBeDefined();
+          expect(loggedInUserMember.editable).toBe(true);
+        });
+      });
+      describe('Manager of department', () => {
+        let res: request.Response;
+        let loggedInUser: typeof USERS[keyof typeof USERS];
+        beforeAll(async () => {
+          loggedInUser = USERS.nonAdminAndEngineerManager;
+          res = await authorizeRequest(
+            request(app).get('/members'),
+            loggedInUser.userId
+          ).expect(200);
+          expect(res.body.members).toBeInstanceOf(Array);
+          expect(res.body.members.length).toBeGreaterThan(1);
+        });
+
+        it('should return all members with all fields present', () => {
+          const { members } = res.body;
+          for (const member of members) {
+            expect(member.salary).toBeDefined();
+            expect(member.age).toBeDefined();
+          }
+        });
       });
     });
     describe('HR member', () => {


### PR DESCRIPTION
Closes #1 

Not exactly using the relations for the shorthand syntax but for `has_permissions`

https://docs.osohq.com/node/reference/polar/polar-syntax.html#shorthand-rules

Shorthand syntax wasn't possible because the relation needs to be checked for the user (Actor).
Not the Member that is being read.